### PR TITLE
FEATURE: Make `title` and `path` annotations optional and infer meaningful defaults

### DIFF
--- a/Classes/Sitegeist/Monocle/Fusion/FusionService.php
+++ b/Classes/Sitegeist/Monocle/Fusion/FusionService.php
@@ -65,12 +65,13 @@ class FusionService extends NeosFusionService
     {
         $styleguideObjects = [];
         if ($fusionAst && $fusionAst['__prototypes']) {
-            foreach ($fusionAst['__prototypes'] as $prototypeName => $prototypeObject) {
+            foreach ($fusionAst['__prototypes'] as $prototypeFullName => $prototypeObject) {
                 if (array_key_exists('__meta', $prototypeObject) && is_array($prototypeObject['__meta']) && array_key_exists('styleguide', $prototypeObject['__meta'])) {
+                    list($prototypeVendor, $prototypeName) = explode(':', $prototypeFullName, 2);
                     $styleguideConfiguration = $prototypeObject['__meta']['styleguide'];
-                    $styleguideObjects[$prototypeName] = [
-                        'title' => (isset($styleguideConfiguration['title'])) ? $styleguideConfiguration['title'] : $prototypeName,
-                        'path' => (isset($styleguideConfiguration['path'])) ? $styleguideConfiguration['path'] : 'other',
+                    $styleguideObjects[$prototypeFullName] = [
+                        'title' => (isset($styleguideConfiguration['title'])) ? $styleguideConfiguration['title'] : implode(' ', array_reverse(explode('.', $prototypeName))),
+                        'path' => (isset($styleguideConfiguration['path'])) ? $styleguideConfiguration['path'] : $prototypeName,
                         'description' => (isset($styleguideConfiguration['description'])) ? $styleguideConfiguration['description'] :  '',
                         'options' => (isset($styleguideConfiguration['options'])) ? $styleguideConfiguration['options'] : null,
                     ];

--- a/README.md
+++ b/README.md
@@ -32,19 +32,43 @@ use Monocle to render Fluid based Prototypes without any limitation.
 To render a prototype as a styleguide-item it simply has to be annotated:
 
 ```
-prototype(Vendor.Package:Components.Headline) < prototype(Neos.Fusion:Tag){
+prototype(Vendor.Package:Components.Headline) < prototype(Neos.Fusion:Tag) {
+
+    #
+    # Styleguide annotation
+    # if this annotation is present (even when empty) 
+    # the prototype is rendered in the styleguide
+    # 
     @styleguide {
-        path = 'atoms.basic'
+        
+        #
+        # Path of the component in the styleguide
+        # Optional: by default the name-part of the component name is used
+        #
+        path = 'Components.Headline'
+        
+        #
+        # The title of the component
+        # Optional:  by default the component name is splitted and reversed  
+        #
         title = 'My Custom Prototype'
+        
+        #
+        # A description of the component
+        # Optional: By default empty.
+        # 
         description = 'A Prototype ....'
         
-        # ts props to override for the styleguide rendering
+        #
+        # Fusion-props to override during the styleguide rendering
+        # Optional: By default empty.
+        # 
         props {
             content = 'Hello World'
         }
     }
 
-    // normal ts props 
+    # normal fusion props 
     tagName = 'h1'
     content = ''
 }


### PR DESCRIPTION
- The default `path` is now the component name (without VendorNamespace)
- The default `title` default is now the component name splittet reversed and glued with spaces again