### PR TITLE
FEATURE: Add styleguide:render CLI command

### DIFF
--- a/Classes/Sitegeist/Monocle/Command/StyleguideCommandController.php
+++ b/Classes/Sitegeist/Monocle/Command/StyleguideCommandController.php
@@ -20,6 +20,7 @@ use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Package\PackageManagerInterface;
 use Symfony\Component\Yaml\Yaml;
 use Sitegeist\Monocle\Service\DummyControllerContextTrait;
+use Sitegeist\Monocle\Service\PackageKeyTrait;
 
 /**
  * Class StyleguideCommandController
@@ -27,13 +28,7 @@ use Sitegeist\Monocle\Service\DummyControllerContextTrait;
  */
 class StyleguideCommandController extends CommandController
 {
-    use DummyControllerContextTrait;
-
-    /**
-     * @Flow\Inject
-     * @var PackageManagerInterface
-     */
-    protected $packageManager;
+    use DummyControllerContextTrait, PackageKeyTrait;
 
     /**
      * @var array
@@ -64,9 +59,7 @@ class StyleguideCommandController extends CommandController
      */
     public function itemsCommand($format = 'json')
     {
-        $sitePackages = $this->packageManager->getFilteredPackages('available', null, 'neos-site');
-        $sitePackage = reset($sitePackages);
-        $sitePackageKey = $sitePackage->getPackageKey();
+        $sitePackageKey = $this->getDefaultSitePackageKey();
 
         $fusionAst = $this->fusionService->getMergedTypoScriptObjectTreeForSitePackage($sitePackageKey);
         $styleguideObjects = $this->fusionService->getStyleguideObjectsFromFusionAst($fusionAst);
@@ -85,15 +78,12 @@ class StyleguideCommandController extends CommandController
         $prototypePreviewRenderPath = FusionService::RENDERPATH_DISCRIMINATOR . str_replace(['.', ':'], ['_', '__'], $prototypeName);
         $controllerContext = $this->createDummyControllerContext();
 
-        //
-        // Extract package key from prototype name
-        //
-        list($packageKey) = explode(':', $prototypeName);
+        $sitePackageKey = $this->getDefaultSitePackageKey();
 
         $typoScriptView = new FusionView();
         $typoScriptView->setControllerContext($controllerContext);
         $typoScriptView->setFusionPath($prototypePreviewRenderPath);
-        $typoScriptView->setPackageKey($packageKey);
+        $typoScriptView->setPackageKey($sitePackageKey);
 
         $this->output($typoScriptView->render());
     }

--- a/Classes/Sitegeist/Monocle/Command/StyleguideCommandController.php
+++ b/Classes/Sitegeist/Monocle/Command/StyleguideCommandController.php
@@ -14,10 +14,12 @@ namespace Sitegeist\Monocle\Command;
  */
 
 use Sitegeist\Monocle\Fusion\FusionService;
+use Sitegeist\Monocle\Fusion\FusionView;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Package\PackageManagerInterface;
 use Symfony\Component\Yaml\Yaml;
+use Sitegeist\Monocle\Service\DummyControllerContextTrait;
 
 /**
  * Class StyleguideCommandController
@@ -25,6 +27,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class StyleguideCommandController extends CommandController
 {
+    use DummyControllerContextTrait;
 
     /**
      * @Flow\Inject
@@ -69,6 +72,30 @@ class StyleguideCommandController extends CommandController
         $styleguideObjects = $this->fusionService->getStyleguideObjectsFromFusionAst($fusionAst);
 
         $this->outputData($styleguideObjects, $format);
+    }
+
+    /**
+     * Render a given fusion component to HTML
+     *
+     * @param string $prototypeName The prototype name of the component
+     * @return void
+     */
+    public function renderCommand($prototypeName)
+    {
+        $prototypePreviewRenderPath = FusionService::RENDERPATH_DISCRIMINATOR . str_replace(['.', ':'], ['_', '__'], $prototypeName);
+        $controllerContext = $this->createDummyControllerContext();
+
+        //
+        // Extract package key from prototype name
+        //
+        list($packageKey) = explode(':', $prototypeName);
+
+        $typoScriptView = new FusionView();
+        $typoScriptView->setControllerContext($controllerContext);
+        $typoScriptView->setFusionPath($prototypePreviewRenderPath);
+        $typoScriptView->setPackageKey($packageKey);
+
+        $this->output($typoScriptView->render());
     }
 
     protected function outputData($data, $format)

--- a/Classes/Sitegeist/Monocle/Controller/ApiController.php
+++ b/Classes/Sitegeist/Monocle/Controller/ApiController.php
@@ -20,6 +20,7 @@ use Neos\Flow\Package\PackageManagerInterface;
 use Sitegeist\Monocle\Fusion\FusionService;
 use Sitegeist\Monocle\Fusion\FusionView;
 use Sitegeist\Monocle\Fusion\ReverseFusionParser;
+use Sitegeist\Monocle\Service\PackageKeyTrait;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -28,17 +29,12 @@ use Symfony\Component\Yaml\Yaml;
  */
 class ApiController extends ActionController
 {
+    use PackageKeyTrait;
 
     /**
      * @var array
      */
     protected $defaultViewObjectName = 'Neos\Flow\Mvc\View\JsonView';
-
-    /**
-     * @Flow\Inject
-     * @var PackageManagerInterface
-     */
-    protected $packageManager;
 
     /**
      * @Flow\Inject
@@ -72,9 +68,7 @@ class ApiController extends ActionController
      */
     public function styleguideObjectsAction()
     {
-        $sitePackages = $this->packageManager->getFilteredPackages('available', null, 'neos-site');
-        $sitePackage = reset($sitePackages);
-        $sitePackageKey = $sitePackage->getPackageKey();
+        $sitePackageKey = $this->getDefaultSitePackageKey();
 
         $fusionAst = $this->fusionService->getMergedTypoScriptObjectTreeForSitePackage($sitePackageKey);
         $styleguideObjects = $this->fusionService->getStyleguideObjectsFromFusionAst($fusionAst);
@@ -134,9 +128,7 @@ class ApiController extends ActionController
      */
     public function renderPrototypeAction($prototypeName)
     {
-        $sitePackages = $this->packageManager->getFilteredPackages('available', null, 'neos-site');
-        $sitePackage = reset($sitePackages);
-        $sitePackageKey = $sitePackage->getPackageKey();
+        $sitePackageKey = $this->getDefaultSitePackageKey();
 
         $prototypePreviewRenderPath = FusionService::RENDERPATH_DISCRIMINATOR . str_replace(['.', ':'], ['_', '__'], $prototypeName);
 

--- a/Classes/Sitegeist/Monocle/Controller/PreviewController.php
+++ b/Classes/Sitegeist/Monocle/Controller/PreviewController.php
@@ -20,6 +20,7 @@ use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\Package\PackageManagerInterface;
 use Sitegeist\Monocle\Fusion\FusionService;
 use Sitegeist\Monocle\Fusion\FusionView;
+use Sitegeist\Monocle\Service\PackageKeyTrait;
 
 /**
  * Class PreviewController
@@ -27,11 +28,7 @@ use Sitegeist\Monocle\Fusion\FusionView;
  */
 class PreviewController extends ActionController
 {
-    /**
-     * @Flow\Inject
-     * @var PackageManagerInterface
-     */
-    protected $packageManager;
+    use PackageKeyTrait;
 
     /**
      * @var array
@@ -109,9 +106,7 @@ class PreviewController extends ActionController
      */
     public function componentAction($prototypeName)
     {
-        $sitePackages = $this->packageManager->getFilteredPackages('available', null, 'neos-site');
-        $sitePackage = reset($sitePackages);
-        $sitePackageKey = $sitePackage->getPackageKey();
+        $sitePackageKey = $this->getDefaultSitePackageKey();
 
         $prototypePreviewRenderPath = FusionService::RENDERPATH_DISCRIMINATOR . str_replace(['.', ':'], ['_', '__'], $prototypeName);
 

--- a/Classes/Sitegeist/Monocle/Service/DummyControllerContextTrait.php
+++ b/Classes/Sitegeist/Monocle/Service/DummyControllerContextTrait.php
@@ -1,0 +1,33 @@
+<?php
+namespace Sitegeist\Monocle\Service;
+
+use Neos\Flow\Http\Request;
+use Neos\Flow\Http\Response;
+use Neos\Flow\Http\Uri;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\Controller\Arguments;
+use Neos\Flow\Mvc\Routing\UriBuilder;
+use Neos\Flow\Mvc\Controller\ControllerContext;
+
+/**
+ * Utility trait to create controller contexts within CLI SAPI
+ */
+trait DummyControllerContextTrait
+{
+    /**
+     * Create a dummy controller context
+     *
+     * @return ControllerContext
+     */
+    protected function createDummyControllerContext()
+    {
+        $httpRequest = Request::create(new Uri('http://neos.io'));
+        $request = new ActionRequest($httpRequest);
+        $response = new Response();
+        $arguments = new Arguments([]);
+        $uriBuilder = new UriBuilder();
+        $uriBuilder->setRequest($request);
+
+        return new ControllerContext($request, $response, $arguments, $uriBuilder);
+    }
+}

--- a/Classes/Sitegeist/Monocle/Service/PackageKeyTrait.php
+++ b/Classes/Sitegeist/Monocle/Service/PackageKeyTrait.php
@@ -1,0 +1,31 @@
+<?php
+namespace Sitegeist\Monocle\Service;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Package\PackageManagerInterface;
+
+/**
+ * Utility trait to determine package keys
+ */
+trait PackageKeyTrait
+{
+
+    /**
+     * @Flow\Inject
+     * @var PackageManagerInterface
+     */
+    protected $packageManager;
+
+    /**
+     * Determine the default package key
+     *
+     * @return string
+     */
+    protected function getDefaultSitePackageKey()
+    {
+        $sitePackages = $this->packageManager->getFilteredPackages('available', null, 'neos-site');
+        $sitePackage = reset($sitePackages);
+
+        return $sitePackage->getPackageKey();
+    }
+}


### PR DESCRIPTION
This adds a `styleguide:render` flow command.

Usage:

```sh
./flow styleguide:render MyAwesome.Package:MyAwesome.Component
```

The result will be the rendered HTML of the given component. This functionality is required to run JS-based unit tests against components.