### PR TITLE
BUGFIX: Add default formats to monocle routes

### DIFF
--- a/Configuration/Routes.yaml
+++ b/Configuration/Routes.yaml
@@ -19,7 +19,8 @@
   defaults:
     '@package': 'Sitegeist.Monocle'
     '@subpackage': ''
-    '@controller' : 'Api'
+    '@controller': 'Api'
+    '@format': 'html'
   httpMethods: ['GET','POST']
 
 -
@@ -28,5 +29,6 @@
   defaults:
     '@package': 'Sitegeist.Monocle'
     '@subpackage': ''
-    '@controller' : 'Preview'
+    '@controller': 'Preview'
+    '@format': 'html'
   httpMethods: ['GET','POST']


### PR DESCRIPTION
This fixes an annoying bug, through which flow couldn't figure out the correct route to redirect to after login. So, when your session timed out, you got to see the Neos login screen after which you got redirected to a 404 page.

By adding `@format` to the default values, this redirect works now.