### PR TITLE
FEATURE: Display viewport dimensions instead of view port name

### DIFF
--- a/Resources/Private/JavaScript/containers/styleguide/header/toolbox/breakpoint-selector/breakpoint-list/breakpoint/index.js
+++ b/Resources/Private/JavaScript/containers/styleguide/header/toolbox/breakpoint-selector/breakpoint-list/breakpoint/index.js
@@ -10,20 +10,20 @@ import style from './style.css';
 export default class Breakpoint extends PureComponent {
     static propTypes = {
         label: PropTypes.string.isRequired,
-        name: PropTypes.string.isRequired,
+        dimensions: PropTypes.string.isRequired,
         handleClick: PropTypes.func.isRequired
     };
 
     render() {
-        const {label, name, handleClick} = this.props;
+        const {label, dimensions, handleClick} = this.props;
 
         return (
             <button className={style.breakpoint} onClick={handleClick}>
                 <div className={style.title}>
                     {label}
                 </div>
-                <div className={style.name}>
-                    {name}
+                <div className={style.dimensions}>
+                    {dimensions}
                 </div>
             </button>
         );

--- a/Resources/Private/JavaScript/containers/styleguide/header/toolbox/breakpoint-selector/breakpoint-list/breakpoint/style.css
+++ b/Resources/Private/JavaScript/containers/styleguide/header/toolbox/breakpoint-selector/breakpoint-list/breakpoint/style.css
@@ -18,7 +18,7 @@
     margin-right: .4em;
 }
 
-.name {
+.dimensions {
     font-size: 80%;
     color: var(--brandColorsContrastBright);
     display: inline-block;

--- a/Resources/Private/JavaScript/containers/styleguide/header/toolbox/breakpoint-selector/breakpoint-list/index.js
+++ b/Resources/Private/JavaScript/containers/styleguide/header/toolbox/breakpoint-selector/breakpoint-list/index.js
@@ -34,15 +34,18 @@ export default class BreakpointList extends PureComponent {
 
     render() {
         const {breakpoints, handleSelectBreakpoint} = this.props;
+        const relevantBreakpoints = Object.keys(breakpoints).filter(name => breakpoints[name])
+            .map(name => ({name, ...breakpoints[name]}));
 
         return (
             <div className={style.list}>
                 <div className={style.breakpoints}>
-                    {Object.keys(breakpoints).map(name => ({name, ...breakpoints[name]})).map(
+                    {relevantBreakpoints.map(
                         breakpoint => (
                             <Breakpoint
                                 key={breakpoint.name}
                                 onClick={handleSelectBreakpoint}
+                                dimensions={`${breakpoint.width}x${breakpoint.height}`}
                                 {...breakpoint}
                                 />
                         )

--- a/Resources/Private/JavaScript/containers/styleguide/header/toolbox/breakpoint-selector/breakpoint-list/style.css
+++ b/Resources/Private/JavaScript/containers/styleguide/header/toolbox/breakpoint-selector/breakpoint-list/style.css
@@ -1,6 +1,6 @@
 .list {
     width: 100vh;
-    max-width: 200px;
+    max-width: 300px;
 }
 
 .breakpoints {


### PR DESCRIPTION
![screenshot_2018-01-16_17-07-37](https://user-images.githubusercontent.com/2522299/34998604-d5da6ed6-fadf-11e7-83f5-82fd1c2e9d16.png)

Makes more sense, right? :)

Also, this PR filters breakpoints that have been deactivated via yaml:

```yaml
Sitegeist:
  Monocle:
    ui:
      viewportPresets:
          l: ~
```

Currently, those entries still show up in the UI.