### PR TITLE
BUGFIX: Fix `Preview.Prototype` `props` and `locales` fusion value types

### DIFF
--- a/Classes/Sitegeist/Monocle/FusionObjects/PreviewPrototypeImplementation.php
+++ b/Classes/Sitegeist/Monocle/FusionObjects/PreviewPrototypeImplementation.php
@@ -60,7 +60,7 @@ class PreviewPrototypeImplementation extends AbstractFusionObject
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function getProps()
     {
@@ -68,7 +68,7 @@ class PreviewPrototypeImplementation extends AbstractFusionObject
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function getLocales()
     {

--- a/Resources/Private/Fusion/Prototypes/Preview/Prototype.fusion
+++ b/Resources/Private/Fusion/Prototypes/Preview/Prototype.fusion
@@ -7,6 +7,6 @@ prototype(Sitegeist.Monocle:Preview.Prototype) {
     sitePackageKey = null
     prototypeName = null
     propSet = null
-    props = null
-    locales = null
+    props = Neos.Fusion:RawArray
+    locales = Neos.Fusion:RawArray
 }


### PR DESCRIPTION
Changes `Sitegeist.Monocle:Preview.Prototype`'s `props` and `locales`
fusion values to be initialized as array to be correctly processed in
Monocle's `FusionView` implementation.

Otherwise overriding a component's properties from within another component's styleguide definition would require specifying `props` as an array instead of just writing

```
prototype(Vendor.Site:Container) {
    @styleguide{
        props.content = Sitegeist.Monocle:Preview.Prototype {
            prototypeName = 'Vendor.Site:Item'
            props {
                foo = 'bar'
            }
        }
    }
    ...
}
```