### PR TITLE
FEATURE: Fusion Object Tree Caching

### DIFF
--- a/Classes/Sitegeist/Monocle/Aspects/FusionCachingAspect.php
+++ b/Classes/Sitegeist/Monocle/Aspects/FusionCachingAspect.php
@@ -1,0 +1,51 @@
+<?php
+namespace Sitegeist\Monocle\Aspects;
+
+/**
+ * This file is part of the Sitegeist.Monocle package
+ *
+ * (c) 2016
+ * Martin Ficzel <ficzel@sitegeist.de>
+ * Wilhelm Behncke <behncke@sitegeist.de>
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Aop\JoinPointInterface;
+use Neos\Cache\Frontend\VariableFrontend;
+
+/**
+ * @Flow\Scope("singleton")
+ * @Flow\Aspect
+ */
+class FusionCachingAspect
+{
+    /**
+     * @Flow\Inject
+     * @var VariableFrontend
+     */
+    protected $fusionCache;
+
+    /**
+     * @Flow\Around("setting(Sitegeist.Monocle.fusion.enableObjectTreeCache) && method(Sitegeist\Monocle\Fusion\FusionService->getMergedFusionObjectTreeForSitePackage())")
+     * @param JoinPointInterface $joinPoint The current join point
+     * @return mixed
+     */
+    public function cacheGetMergedFusionObjectTree(JoinPointInterface $joinPoint)
+    {
+        $siteResourcesPackageKey = $joinPoint->getMethodArgument('siteResourcesPackageKey');
+        $cacheIdentifier = str_replace('.', '_', $siteResourcesPackageKey);
+
+        if ($this->fusionCache->has($cacheIdentifier)) {
+            $fusionObjectTree = $this->fusionCache->get($cacheIdentifier);
+        } else {
+            $fusionObjectTree = $joinPoint->getAdviceChain()->proceed($joinPoint);
+            $this->fusionCache->set($cacheIdentifier, $fusionObjectTree);
+        }
+
+        return $fusionObjectTree;
+    }
+}

--- a/Classes/Sitegeist/Monocle/Package.php
+++ b/Classes/Sitegeist/Monocle/Package.php
@@ -1,0 +1,79 @@
+<?php
+namespace Sitegeist\Monocle;
+
+/**
+ * This file is part of the Sitegeist.Monocle package
+ *
+ * (c) 2016
+ * Martin Ficzel <ficzel@sitegeist.de>
+ * Wilhelm Behncke <behncke@sitegeist.de>
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Cache\CacheManager;
+use Neos\Flow\Core\Booting\Sequence;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Monitor\FileMonitor;
+use Neos\Flow\Package\FlowPackageInterface;
+use Neos\Flow\Package\Package as BasePackage;
+use Neos\Flow\Package\PackageManager;
+use Neos\Flow\Package\PackageManagerInterface;
+
+/**
+ * The Fluid Package
+ *
+ */
+class Package extends BasePackage
+{
+
+    /**
+     * Invokes custom PHP code directly after the package manager has been initialized.
+     *
+     * @param Bootstrap $bootstrap The current bootstrap
+     * @return void
+     */
+    public function boot(Bootstrap $bootstrap)
+    {
+        $dispatcher = $bootstrap->getSignalSlotDispatcher();
+
+        $context = $bootstrap->getContext();
+        if (!$context->isProduction()) {
+            $dispatcher->connect(Sequence::class, 'afterInvokeStep', function ($step) use ($bootstrap, $dispatcher) {
+                if ($step->getIdentifier() === 'neos.flow:systemfilemonitor') {
+                    $templateFileMonitor = FileMonitor::createFileMonitorAtBoot('Sitegeist_Monocle_Fusion_Files', $bootstrap);
+                    $packageManager = $bootstrap->getEarlyInstance(PackageManagerInterface::class);
+                    /**
+                     * @var PackageManager $packageKey
+                     * @var FlowPackageInterface $package
+                     */
+                    foreach ($packageManager->getFlowPackages() as $packageKey => $package) {
+                        $templatesPath = $package->getResourcesPath() . 'Private/Fusion';
+                        if (is_dir($templatesPath)) {
+                            $templateFileMonitor->monitorDirectory($templatesPath);
+                        }
+                    }
+
+                    $templateFileMonitor->detectChanges();
+                    $templateFileMonitor->shutdownObject();
+                }
+            });
+        }
+
+        $flushTemplates = function ($identifier, $changedFiles) use ($bootstrap) {
+            if ($identifier !== 'Sitegeist_Monocle_Fusion_Files') {
+                return;
+            }
+
+            if ($changedFiles === []) {
+                return;
+            }
+
+            $templateCache = $bootstrap->getObjectManager()->get(CacheManager::class)->getCache('Sitegeist_Monocle_Fusion');
+            $templateCache->flush();
+        };
+        $dispatcher->connect(FileMonitor::class, 'filesHaveChanged', $flushTemplates);
+    }
+}

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,0 +1,3 @@
+Sitegeist_Monocle_Fusion:
+  frontend: Neos\Cache\Frontend\VariableFrontend
+  backend: Neos\Cache\Backend\FileBackend

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -2,3 +2,13 @@ Sitegeist\Monocle\Fusion\FusionView:
   properties:
     fallbackView:
       object: Neos\FluidAdaptor\View\TemplateView
+
+Sitegeist\Monocle\Aspects\FusionCachingAspect:
+  properties:
+    fusionCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Sitegeist_Monocle_Fusion

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,6 +1,9 @@
 
 Sitegeist:
   Monocle:
+    fusion:
+      enableObjectTreeCache: true
+
     packages: {  }
 
     ui:

--- a/README.md
+++ b/README.md
@@ -270,6 +270,14 @@ Sitegeist:
                 height: 1000    
 ```
 
+### Fusion Object Tree Caching
+
+Monocle will cache the fusion code for every site package. To invalidate this cache
+the the Fusion directories of all packages are monitored and changes trigger the flushing
+of the fusion-cache.
+
+The setting `Sitegeist.Monocle.fusion.enableObjectTreeCache` enables the caching in Monocle by default.
+
 ### Routes
 
 The monocle Routes are included automatically via Settings.


### PR DESCRIPTION
Monocle will cache the fusion code for every site package. To invalidate this cache
the the Fusion directories of all packages are monitored and changes trigger the flushing
of the fusion-cache.

The setting `Sitegeist.Monocle.fusion.enableObjectTreeCache` enables the caching in
Monocle by default.