### PR TITLE
FEATURE: Sitegeist.Monocle:MirrorUri endpoint

### DIFF
--- a/Classes/Sitegeist/Monocle/Controller/MockController.php
+++ b/Classes/Sitegeist/Monocle/Controller/MockController.php
@@ -1,0 +1,37 @@
+<?php
+namespace Sitegeist\Monocle\Controller;
+
+/**
+ * This file is part of the Sitegeist.Monocle package
+ *
+ * (c) 2016
+ * Martin Ficzel <ficzel@sitegeist.de>
+ * Wilhelm Behncke <behncke@sitegeist.de>
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ActionController;
+
+/**
+ * Class MockController
+ * @package Sitegeist\Monocle\Controller
+ */
+class MockController extends ActionController
+{
+    /**
+     * Return the given content and the type header
+     *
+     * @param string $content
+     * @param string $type
+     * @return void
+     */
+    public function mirrorAction($content = '', $type = 'text/html')
+    {
+        $this->response->setHeader('Content-Type', $type);
+        return $content;
+    }
+}

--- a/Configuration/Development/Policy.yaml
+++ b/Configuration/Development/Policy.yaml
@@ -10,3 +10,6 @@ roles:
       -
         privilegeTarget: 'Sitegeist.Monocle:Styleguide.Module'
         permission: GRANT
+      -
+        privilegeTarget: 'Sitegeist.Monocle:Styleguide.Mock'
+        permission: GRANT

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -8,6 +8,8 @@ privilegeTargets:
       matcher: 'method(Sitegeist\Monocle\Controller\ModuleController->(index)Action())'
     'Sitegeist.Monocle:Styleguide.Api':
       matcher: 'method(Sitegeist\Monocle\Controller\ApiController->(styleguideObjects|styleguideResources|sitePackages|viewportPresets|localePresets|renderPrototype)Action())'
+    'Sitegeist.Monocle:Styleguide.Mock':
+      matcher: 'method(Sitegeist\Monocle\Controller\MockController->(mirror)Action())'
 
 roles:
   'Neos.Neos:AbstractEditor':
@@ -23,4 +25,7 @@ roles:
         permission: GRANT
       -
         privilegeTarget: 'Sitegeist.Monocle:Styleguide.Module'
+        permission: GRANT
+      -
+        privilegeTarget: 'Sitegeist.Monocle:Styleguide.Mock'
         permission: GRANT

--- a/Configuration/Routes.yaml
+++ b/Configuration/Routes.yaml
@@ -24,6 +24,17 @@
   httpMethods: ['GET','POST']
 
 -
+  name:  'Monocle Mock'
+  uriPattern: 'monocle/mock/{@action}'
+  defaults:
+    '@package': 'Sitegeist.Monocle'
+    '@subpackage': ''
+    '@controller': 'Mock'
+    '@format': 'text'
+  httpMethods: ['GET','POST']
+  appendExceedingArguments: true
+
+-
   name:  'Monocle Preview - Module'
   uriPattern: 'monocle/preview/module'
   defaults:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ use Monocle to render Fluid based Prototypes without any limitation.
 
 ## Installation
 
-Sitegeist.Monocle is available via packagist. `"sitegeist/monocle" : "~4.0"` to the require section of the composer.json 
+Sitegeist.Monocle is available via packagist. `"sitegeist/monocle" : "~4.0"` to the require section of the composer.json
 or run `composer require sitegeist/monocle`.
 
 We use semantic-versioning so every breaking change will increase the major-version number.
@@ -69,7 +69,7 @@ prototype(Vendor.Package:Components.Headline) < prototype(Neos.Fusion:Tag) {
         props {
             content = 'Hello World'
         }
-        
+
         #
         # Alternate prop sets that can overload the default props
         # Optional: By default empty.
@@ -116,11 +116,45 @@ presentational-components vs. container-components in the ReactJS world.
 
 Monocle has fusion-prototypes to simulate json api responses for components.
 
-- `Sitegeist.Monocle:DataUri`: Generic data uri implementation that expects `type` and `content` as string
+#### `Sitegeist.Monocle:DataUri`
+
+Generic data uri implementation that expects `type` and `content` as string
+
+```
+    endpointUrl = Sitegeist.Monocle:DataUri {
+        content = '{"hello":"world"}'
+        type = 'application/json'
+    }
+```
+
+The DataUri-Prototypes will encode the content as base64.
+Attention: Data Uris do not accept url-parameters. If you frontend code adds arguments to the mock you have to be aware of that.
+
+For convenience special prototypes for json and text exist:
+
 - `Sitegeist.Monocle:DataUri.Json`: And endpoint-mock with media-type `application/json` that will pass `content` trough Json.stringify
 - `Sitegeist.Monocle:DataUri.Text`: And endpoint-mock with media-type `text/plain`
 
-The DataUri-Prototypes will encode the content as base64.
+#### `Sitegeist.Monocle:MirrorUri`
+
+Create an uri to an monocle endpoint that returns the passed content with the given type
+
+```
+    endpointUrl = Sitegeist.Monocle:MirrorUri {
+        content = '{"hello":"world"}'
+        type = 'application/json'
+    }
+```
+
+Attention: Browsers will often crop the urls to a maximal length, be aware of that if you mock large json-structures.
+
+For convenience special prototypes for json and text exist:
+
+- `Sitegeist.Monocle:MirrorUri.Json`: And endpoint-mock with media-type `application/json` that accepts RawArray data
+- `Sitegeist.Monocle:MirrorUri.Text`: And endpoint-mock with media-type `text/plain`
+
+
+#### Mocking Uris inside the styleguide
 
 ```
 prototype(Vendor.Package:Component.SearchExample) < prototype(Neos.Fusion:Component) {
@@ -151,33 +185,33 @@ Some configuration is available to configure the preview.
 Sitegeist:
   Monocle:
     preview:
-        # 
-        # The fusion path that renders the preview. 
-        # the available context is has the values 
+        #
+        # The fusion path that renders the preview.
+        # the available context is has the values
         #  - sitePackageKey
         #  - prototypeName
         #  - propSet
-        #  - props  
-        # 
+        #  - props
+        #
         fusionRootPath: '/<Sitegeist.Monocle:Preview.Page>'
-        
-        # 
+
+        #
         # The fusion prototype that is rendered initially
         # Optional: Will default to the first found prototype
         #
         defaultPrototypeName: 'Vendor.Site:Prototype'
-  
-        # 
-        # The query selector that is used to extract the component html 
-        # from the preview to the html-view. 
+
+        #
+        # The query selector that is used to extract the component html
+        # from the preview to the html-view.
         # Optional: Default is 'body'
-        #       
+        #
         sourceQuerySelector: 'body'
 
 ```
 
-To include your styles and scripts into the preview you can extend the `Sitegeist.Monocle:Preview.Page` prototype the 
-same way you would customize `Neos.Neos:Page`. 
+To include your styles and scripts into the preview you can extend the `Sitegeist.Monocle:Preview.Page` prototype the
+same way you would customize `Neos.Neos:Page`.
 
 ```
 //
@@ -192,13 +226,13 @@ prototype(Sitegeist.Monocle:Preview.Page) {
     bodyScripts = Vendor.Site:Resources.BodyScripts {
         @position = 'before closingBodyTag'
     }
-} 
+}
 
 ```
 
 #### Viewports
 
-To configure the available viewport presets you can alter the following configuration. 
+To configure the available viewport presets you can alter the following configuration.
 
 ```YAML
 Sitegeist:
@@ -310,7 +344,7 @@ Sitegeist:
               xxl:
                 label: 'extra wide'
                 width: 1600
-                height: 1000    
+                height: 1000
 ```
 
 ### Fusion Object Tree Caching
@@ -331,13 +365,13 @@ Sitegeist.Monocle brings some fusion-prototypes that you can use or adjust to yo
 
 #### `Sitegeist.Monocle:Preview.Page`
 
-The prototype `Sitegeist.Monocle:Preview.Page` renders the preview view for a prototype, to do so it uses `Sitegeist.Monocle:Preview.Prototype` below. 
-You can extend this prototype to add your styles and scripts as you would with `Neos.Neos:Page`. 
+The prototype `Sitegeist.Monocle:Preview.Page` renders the preview view for a prototype, to do so it uses `Sitegeist.Monocle:Preview.Prototype` below.
+You can extend this prototype to add your styles and scripts as you would with `Neos.Neos:Page`.
 
 #### `Sitegeist.Monocle:Preview.Prototype`
 
-The prototype `Sitegeist.Monocle:Preview.Prototype` is used to render a single prototype with applied styleguide props. 
-This is useful if you want to provide the result as prop to the preview of another prototype. 
+The prototype `Sitegeist.Monocle:Preview.Prototype` is used to render a single prototype with applied styleguide props.
+This is useful if you want to provide the result as prop to the preview of another prototype.
 
 ```
 prototype(Vendor.Site:Container) {
@@ -355,7 +389,7 @@ prototype(Vendor.Site:Container) {
 
 Monocle comes with four privilege targets to control access.
 
-- `Sitegeist.Monocle:Backend.Styleguide` : call the backend module that will open the styleguide 
+- `Sitegeist.Monocle:Backend.Styleguide` : call the backend module that will open the styleguide
 - `Sitegeist.Monocle:Styleguide.Api` : request informations about prototypes etc. via api (used from the module)
 - `Sitegeist.Monocle:Styleguide.Preview` : show a preview for a prototype
 - `Sitegeist.Monocle:Styleguide.Module` : show the styleguide

--- a/Resources/Private/Fusion/Prototypes/DataUri/DataUri.fusion
+++ b/Resources/Private/Fusion/Prototypes/DataUri/DataUri.fusion
@@ -1,6 +1,6 @@
 prototype(Sitegeist.Monocle:DataUri) {
-	@class = 'Sitegeist\\Monocle\\FusionObjects\\DataUriImplementation'
+    @class = 'Sitegeist\\Monocle\\FusionObjects\\DataUriImplementation'
 
-	type = null
-	content = null
+    type = null
+    content = null
 }

--- a/Resources/Private/Fusion/Prototypes/DataUri/Json.fusion
+++ b/Resources/Private/Fusion/Prototypes/DataUri/Json.fusion
@@ -1,8 +1,8 @@
 prototype(Sitegeist.Monocle:DataUri.Json) < prototype(Neos.Fusion:Component) {
-	content = null
+    content = null
 
-	renderer = Sitegeist.Monocle:DataUri {
-		type = 'application/json'
-		content = ${Json.stringify(props.content)}
-	}
+    renderer = Sitegeist.Monocle:DataUri {
+        type = 'application/json'
+        content = ${Json.stringify(props.content)}
+    }
 }

--- a/Resources/Private/Fusion/Prototypes/DataUri/Text.fusion
+++ b/Resources/Private/Fusion/Prototypes/DataUri/Text.fusion
@@ -1,8 +1,8 @@
 prototype(Sitegeist.Monocle:DataUri.Text) < prototype(Neos.Fusion:Component) {
-	content = null
+    content = null
 
-	renderer = Sitegeist.Monocle:DataUri {
-		type = 'text/plain'
-		content = ${props.content}
-	}
+    renderer = Sitegeist.Monocle:DataUri {
+        type = 'text/plain'
+        content = ${props.content}
+    }
 }

--- a/Resources/Private/Fusion/Prototypes/MirrorUri/Json.fusion
+++ b/Resources/Private/Fusion/Prototypes/MirrorUri/Json.fusion
@@ -1,0 +1,8 @@
+prototype(Sitegeist.Monocle:MirrorUri.Json) < prototype(Neos.Fusion:Component) {
+    content = null
+
+    renderer = Sitegeist.Monocle:MirrorUri {
+        type = 'application/json'
+        content = ${Json.stringify(props.content)}
+    }
+}

--- a/Resources/Private/Fusion/Prototypes/MirrorUri/MirrorUri.fusion
+++ b/Resources/Private/Fusion/Prototypes/MirrorUri/MirrorUri.fusion
@@ -1,0 +1,15 @@
+prototype(Sitegeist.Monocle:MirrorUri) < prototype(Neos.Fusion:Component) {
+    type = null
+    content = null
+
+    renderer = Neos.Fusion:UriBuilder {
+        package = 'Sitegeist.Monocle'
+        controller = 'Mock'
+        action = 'mirror'
+        format = 'text'
+        arguments {
+            content = ${props.content}
+            type = ${props.type}
+        }
+    }
+}

--- a/Resources/Private/Fusion/Prototypes/MirrorUri/Text.fusion
+++ b/Resources/Private/Fusion/Prototypes/MirrorUri/Text.fusion
@@ -1,0 +1,8 @@
+prototype(Sitegeist.Monocle:MirrorUri.Text) < prototype(Neos.Fusion:Component) {
+    content = null
+
+    renderer = Sitegeist.Monocle:MirrorUri {
+        type = 'text/plain'
+        content = ${props.content}
+    }
+}


### PR DESCRIPTION
The fusion prototype `Sitegeist.Monocle:MirrorUri` creates an uri to an monocle-endpoint that returns the passed content with the given type

```
endpointUrl = Sitegeist.Monocle:MirrorUri {
  content = '{"hello":"world"}'
  type = 'application/json'
}
```

For convenience special prototypes for json and text exist aswell:

- `Sitegeist.Monocle:MirrorUri.Json`: And endpoint-mock with media-type `application/json` that accepts RawArray data
- `Sitegeist.Monocle:MirrorUri.Text`: And endpoint-mock with media-type `text/plain`