### PR TITLE
FEATURE: Add Sitegeist.Monocle:StaticUri prototype

### DIFF
--- a/Classes/Sitegeist/Monocle/Controller/MockController.php
+++ b/Classes/Sitegeist/Monocle/Controller/MockController.php
@@ -15,6 +15,7 @@ namespace Sitegeist\Monocle\Controller;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Flow\Property\Exception\TargetNotFoundException;
 
 /**
  * Class MockController
@@ -22,6 +23,13 @@ use Neos\Flow\Mvc\Controller\ActionController;
  */
 class MockController extends ActionController
 {
+
+    /**
+     * @var array
+     * @Flow\InjectConfiguration(path="uriMock.static")
+     */
+    protected $staticUriMocks;
+
     /**
      * Return the given content and the type header
      *
@@ -33,5 +41,22 @@ class MockController extends ActionController
     {
         $this->response->setHeader('Content-Type', $type);
         return $content;
+    }
+
+    /**
+     * Return the given static content as defined in the configuration
+     *
+     * @param string $key
+     * @return void
+     */
+    public function staticAction($key)
+    {
+        if ($key && is_array($this->staticUriMocks) && array_key_exists($key, $this->staticUriMocks)) {
+            $config = $this->staticUriMocks[$key];
+            $this->response->setHeader('Content-Type', $config['contentType']);
+            return file_get_contents($config['path']);
+        }
+
+        throw new TargetNotFoundException();
     }
 }

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -9,7 +9,7 @@ privilegeTargets:
     'Sitegeist.Monocle:Styleguide.Api':
       matcher: 'method(Sitegeist\Monocle\Controller\ApiController->(styleguideObjects|styleguideResources|sitePackages|viewportPresets|localePresets|renderPrototype)Action())'
     'Sitegeist.Monocle:Styleguide.Mock':
-      matcher: 'method(Sitegeist\Monocle\Controller\MockController->(mirror)Action())'
+      matcher: 'method(Sitegeist\Monocle\Controller\MockController->(mirror|static)Action())'
 
 roles:
   'Neos.Neos:AbstractEditor':

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,6 +1,13 @@
 
 Sitegeist:
   Monocle:
+    uriMock:
+      #the static file uris to mock
+      static: {}
+      # key:
+      #   path: 'resource://Vendor.Package/Private/Json/example.json'
+      #   contentType: 'application/json'
+
     fusion:
       enableObjectTreeCache: true
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,28 @@ For convenience special prototypes for json and text exist:
 - `Sitegeist.Monocle:MirrorUri.Text`: And endpoint-mock with media-type `text/plain`
 
 
+#### `Sitegeist.Monocle:StaticUri`
+
+Create an URI that will return the content of the file and the contentType for the given key.
+
+```
+    endpointUrl = Sitegeist.Monocle:StaticUri {
+        key = 'example'
+    }
+```
+
+The path and content type for each key are configured via Settings:
+
+```yaml
+Sitegeist:
+  Monocle:
+    uriMock:
+      static:
+        example:
+          path: 'resource://Vendor.Package/Private/Json/example.json'
+          contentType: 'application/json'
+```
+
 #### Mocking Uris inside the styleguide
 
 ```

--- a/Resources/Private/Fusion/Prototypes/StaticUri/StaticUri.fusion
+++ b/Resources/Private/Fusion/Prototypes/StaticUri/StaticUri.fusion
@@ -1,0 +1,14 @@
+prototype(Sitegeist.Monocle:StaticUri) < prototype(Neos.Fusion:Component) {
+    key = null
+
+    renderer = Neos.Fusion:UriBuilder {
+        package = 'Sitegeist.Monocle'
+        controller = 'Mock'
+        action = 'static'
+        format = 'text'
+        arguments {
+            key = ${props.key}
+        }
+    }
+
+}


### PR DESCRIPTION
The prototype creates an URI that will return the content of the file and the contentType for the given key.

```
    endpointUrl = Sitegeist.Monocle:StaticUri {
        key = 'example'
    }
```

The path and content type for each key are configured via Settings:

```yaml
Sitegeist:
  Monocle:
    uriMock:
      static:
        example:
          path: 'resource://Vendor.Package/Private/Json/example.json'
          contentType: 'application/json'
```