### PR TITLE
BUGFIX: Render prototypes and props in isolation by using a wrapper component

### DIFF
--- a/Classes/Sitegeist/Monocle/Command/StyleguideCommandController.php
+++ b/Classes/Sitegeist/Monocle/Command/StyleguideCommandController.php
@@ -85,12 +85,10 @@ class StyleguideCommandController extends CommandController
     {
         $sitePackageKey = $packageKey ?: $this->getDefaultSitePackageKey();
 
-        $prototypePreviewRenderPath = FusionService::RENDERPATH_DISCRIMINATOR . str_replace(['.', ':'], ['_', '__'], $prototypeName);
         $controllerContext = $this->createDummyControllerContext();
 
         $fusionView = new FusionView();
         $fusionView->setControllerContext($controllerContext);
-        $fusionView->setFusionPath($prototypePreviewRenderPath);
         $fusionView->setPackageKey($sitePackageKey);
 
         $convertedProps = json_decode($props, true) ?? [];

--- a/Classes/Sitegeist/Monocle/Fusion/FusionService.php
+++ b/Classes/Sitegeist/Monocle/Fusion/FusionService.php
@@ -62,9 +62,8 @@ class FusionService extends NeosFusionService
         $mergedFusionCode .= $this->getFusionIncludes($this->appendFusionIncludes);
 
         $fusionAst = $this->fusionParser->parse($mergedFusionCode, $siteRootFusionPathAndFilename);
-        $finalFusionAst = $this->addStyleguidePrototypesToFusionAst($fusionAst);
 
-        return $finalFusionAst;
+        return $fusionAst;
     }
 
 
@@ -132,47 +131,5 @@ class FusionService extends NeosFusionService
                 'children' => $result
             ];
         }
-    }
-
-    /**
-     * Add styleguide rendering configuration to the fusion-ast
-     *
-     * @param array $fusionAst
-     * @return array
-     */
-    protected function addStyleguidePrototypesToFusionAst($fusionAst)
-    {
-        $styleguidePrototypeConfigurations = [];
-        $styleguideRenderingPrototypes = [];
-        $styleguidePenderingProps = [];
-
-        foreach ($fusionAst['__prototypes'] as $prototypeName => $prototypeConfiguration) {
-            if (array_key_exists('__meta', $prototypeConfiguration)
-                && array_key_exists('styleguide', $prototypeConfiguration['__meta'])
-            ) {
-                $styleguidePrototypeConfigurations[$prototypeName] = $prototypeConfiguration;
-            }
-        }
-
-        // create rendering prototypes with dummy data
-        foreach ($styleguidePrototypeConfigurations as $prototypeName => $prototypeConfiguration) {
-            $renderPrototypeFusion = [
-                '__objectType' => $prototypeName,
-                '__value' => null,
-                '__eelExpression' => null
-            ];
-            if (array_key_exists('props', $prototypeConfiguration['__meta']['styleguide']) && is_array($prototypeConfiguration['__meta']['styleguide']['props'])) {
-                $styleguidePenderingProps[$prototypeName] = $prototypeConfiguration['__meta']['styleguide']['props'];
-            }
-            $styleguideRenderingPrototypes[$prototypeName] = $renderPrototypeFusion;
-        }
-
-        // create render pathes
-        foreach ($styleguideRenderingPrototypes as $prototypeName => $prototypeConfiguration) {
-            $key = self::RENDERPATH_DISCRIMINATOR . str_replace(['.', ':'], ['_', '__'], $prototypeName);
-            $fusionAst[$key] = $prototypeConfiguration;
-        }
-
-        return $fusionAst;
     }
 }

--- a/Classes/Sitegeist/Monocle/FusionObjects/PreviewPrototypeImplementation.php
+++ b/Classes/Sitegeist/Monocle/FusionObjects/PreviewPrototypeImplementation.php
@@ -88,12 +88,10 @@ class PreviewPrototypeImplementation extends AbstractFusionObject
         $props = $this->getProps();
         $locales = $this->getLocales();
 
-        $prototypePreviewRenderPath = FusionService::RENDERPATH_DISCRIMINATOR . str_replace(['.', ':'], ['_', '__'], $prototypeName);
 
         // render html
         $fusionView = new FusionView();
         $fusionView->setControllerContext($this->getRuntime()->getControllerContext());
-        $fusionView->setFusionPath($prototypePreviewRenderPath);
         $fusionView->setPackageKey($sitePackageKey);
 
         $html = $fusionView->renderStyleguidePrototype($prototypeName, $propSet, $props, $locales);

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "neos/neos": "*"
+        "neos/neos": "^3.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This makes sure the styleguide props are only evaluated for the currently rendered prototype
and that the fusion of the styleguide props does not interfere with the default fusion.

Now all props have to be passed explicitly to the child-components as styleguide props are only preset
for the actually rendered component.