### PR TITLE
FEATURE: Allow defining of whole props and propSets as Fusion prototypes or expressions

### DIFF
--- a/Classes/FusionObjects/CanRenderImplementation.php
+++ b/Classes/FusionObjects/CanRenderImplementation.php
@@ -1,0 +1,47 @@
+<?php
+namespace Sitegeist\Monocle\FusionObjects;
+
+use Neos\Fusion\FusionObjects\AbstractFusionObject;
+
+/**
+ * CanRender Fusion-Object
+ *
+ * The CanRender Fusion object checks whether the given type can be rendered
+ */
+class CanRenderImplementation extends AbstractFusionObject
+{
+
+    /**
+     * Fusion path which shall be checked
+     *
+     * @return string
+     */
+    public function getRenderPath()
+    {
+        return $this->fusionValue('renderPath');
+    }
+
+    /**
+     * Fusion type which shall be checked
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->fusionValue('type');
+    }
+
+    /**
+     * @return boolean
+     */
+    public function evaluate()
+    {
+        if ($this->getRenderPath()) {
+            return $this->runtime->canRender($this->getRenderPath());
+        } elseif ($this->getType()) {
+            return $this->runtime->canRender('/type<' . $this->getType() . '>');
+        } else {
+            return false;
+        }
+    }
+}

--- a/Resources/Private/Fusion/Prototypes/CanRender/CanRender.fusion
+++ b/Resources/Private/Fusion/Prototypes/CanRender/CanRender.fusion
@@ -1,0 +1,5 @@
+prototype(Sitegeist.Monocle:CanRender) {
+    @class = 'Sitegeist\\Monocle\\FusionObjects\\CanRenderImplementation'
+    type = null
+    path = null
+}

--- a/Resources/Private/Fusion/Prototypes/Preview/Prototype.fusion
+++ b/Resources/Private/Fusion/Prototypes/Preview/Prototype.fusion
@@ -10,13 +10,44 @@ prototype(Sitegeist.Monocle:Preview.Prototype) < prototype(Neos.Fusion:Component
         type = ${props.prototypeName}
         element {
             @apply {
-                defaultProps = Neos.Fusion:Renderer {
-                    renderPath = ${'/<' + props.prototypeName + '>/__meta/styleguide/props<Neos.Fusion:RawArray>'}
+
+                defaultProps = Neos.Fusion:Case {
+                    directly {
+                        condition = Sitegeist.Monocle:CanRender {
+                            renderPath = ${'/<' + props.prototypeName + '>/__meta/styleguide/props'}
+                        }
+                        renderer = Neos.Fusion:Renderer {
+                            renderPath = ${'/<' + props.prototypeName + '>/__meta/styleguide/props'}
+                        }
+                    }
+
+                    asRawArray {
+                        condition = true
+                        renderer = Neos.Fusion:Renderer {
+                            renderPath = ${'/<' + props.prototypeName + '>/__meta/styleguide/props<Neos.Fusion:RawArray>'}
+                        }
+                    }
                 }
-                selectedPropSet = Neos.Fusion:Renderer {
+
+                selectedPropSet = Neos.Fusion:Case {
                     @if.has = ${props.propSet}
-                    renderPath = ${'/<' + props.prototypeName + '>/__meta/styleguide/propSets/' + props.propSet + '<Neos.Fusion:RawArray>'}
+                    directly {
+                        condition = Sitegeist.Monocle:CanRender {
+                            renderPath = ${'/<' + props.prototypeName + '>/__meta/styleguide/propSets/' + props.propSet}
+                        }
+                        renderer = Neos.Fusion:Renderer {
+                            renderPath = ${'/<' + props.prototypeName + '>/__meta/styleguide/propSets/' + props.propSet}
+                        }
+                    }
+
+                    asRawArray {
+                        condition = true
+                        renderer = Neos.Fusion:Renderer {
+                            renderPath = ${'/<' + props.prototypeName + '>/__meta/styleguide/propSets/' + props.propSet + '<Neos.Fusion:RawArray>'}
+                        }
+                    }
                 }
+
                 props = ${props.props}
             }
         }


### PR DESCRIPTION
Defining whole props and propSets as Expressions or Fusion prototypes allows to
centralize the fixtures and even extract them into separate json files.

When props or propSets cannot be evaluated directly the keys below are evaluated
as RawArray as before so this change is a non breaking feature.

```
prototype (Vendor.Site:Example) < prototype(Neos.Fusion:Component) {
    @styleguide {
        propSets {
	    fromEelExpression = ${{title: 'hello world'}}
	    fromFusionPrototype = Vendor.Site:Example.Fixtures
	    fromJsonFile = ${Json.parse(File.readFile('_path_to_fixctures.json'), true)}	}
    }
}
```