### PR TITLE
FEATURE: Prototype Whitelist

### DIFF
--- a/Classes/Controller/ApiController.php
+++ b/Classes/Controller/ApiController.php
@@ -165,10 +165,14 @@ class ApiController extends ActionController
 
         $hiddenPrototypeNamePatterns = $this->configurationService->getSiteConfiguration($sitePackageKey, 'hiddenPrototypeNamePatterns');
         if (is_array($hiddenPrototypeNamePatterns)) {
+            $alwaysShowPrototypes = $this->configurationService->getSiteConfiguration($sitePackageKey, 'alwaysShowPrototypes');
             foreach ($hiddenPrototypeNamePatterns as $pattern) {
                 $styleguideObjects = array_filter(
                     $styleguideObjects,
-                    function ($prototypeName) use ($pattern) {
+                    function ($prototypeName) use ($pattern, $alwaysShowPrototypes) {
+                        if (in_array($prototypeName, $alwaysShowPrototypes, true)) {
+                            return true;
+                        }
                         return fnmatch($pattern, $prototypeName) === false;
                     },
                     ARRAY_FILTER_USE_KEY

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -70,6 +70,7 @@ Sitegeist:
           color: '#FFF'
 
     hiddenPrototypeNamePatterns: {  }
+    alwaysShowPrototypes: {  }
 
     preview:
       fusionRootPath: '/<Sitegeist.Monocle:Preview.Page>'

--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ Sitegeist:
       - 'Another.Vendor.Site:Prototype'
 ```
 
+Specific components can be "unhidden" even if they match one of the `hiddenPrototypeNamePatterns` patterns:
+
+```YAML
+Sitegeist:
+  Monocle:
+    alwaysShowPrototypes:
+      - 'Vendor.Site:Some.Component.ThatShouldBeShown'
+      - 'Another.Vendor.Site:Prototype.ThatShouldBeShown'
+```
+
+This allows for including prototypes of packages selectively.
+
 ### Site-specific configuration
 
 All configurations can be overwritten for each selected site package.


### PR DESCRIPTION
Adds a new configuration option `alwaysShowPrototypes` that allows
for including prototypes selectively even though they match a
configured `hiddenPrototypeNamePatterns`:

```yaml
Sitegeist:
  Monocle:
    hiddenPrototypeNamePatterns:
      - 'Vendor.Components:*'
    alwaysShowPrototypes:
      - 'Vendor.Components:Components.Atom.SomeAtom'
      - 'Vendor.Components:Components.Molecule.SomeMolecule'
```

Resolves: #89