### PR TITLE
FEATURE: Preview for non site packages

### DIFF
--- a/Classes/Service/PackageKeyTrait.php
+++ b/Classes/Service/PackageKeyTrait.php
@@ -18,6 +18,12 @@ trait PackageKeyTrait
     protected $packageManager;
 
     /**
+     * @Flow\InjectConfiguration("packages")
+     * @var mixed[]
+     */
+    protected $packageConfigurations;
+
+    /**
      * Determine the default site package key
      *
      * @return string
@@ -30,16 +36,17 @@ trait PackageKeyTrait
 
     /**
      * Get a list of all active site package keys
-     * @return array
+     * @return string[]
      */
-    protected function getActiveSitePackageKeys()
+    protected function getActiveSitePackageKeys(): array
     {
         $sitePackages = $this->packageManager->getFilteredPackages('available', null, 'neos-site');
-        $result = [];
+        $sitePackageKeys = [];
         foreach ($sitePackages as $sitePackage) {
             $packageKey = $sitePackage->getPackageKey();
-            $result[] = $packageKey;
+            $sitePackageKeys[] = $packageKey;
         }
-        return $result;
+        $configuredPackageKeys = $this->packageConfigurations ? array_keys($this->packageConfigurations) : [];
+        return array_unique(array_merge($sitePackageKeys, $configuredPackageKeys));
     }
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -11,6 +11,8 @@ Sitegeist:
     fusion:
       enableObjectTreeCache: true
 
+    defaultPackageKey: null
+
     packages: {  }
 
     ui:

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Sitegeist:
 
 This allows for including prototypes of packages selectively.
 
-### Site-specific configuration
+### Package-specific configuration
 
 All configurations can be overwritten for each selected site package.
 
@@ -367,6 +367,19 @@ Sitegeist:
                 label: 'extra wide'
                 width: 1600
                 height: 1000
+```
+
+This packages configuration can also be used to configure non-site packages for previewing in the styleguide.
+
+When a prototyope of a non-site package is rendered Monocle will only load the Root.fusion of this specific package and the Monocle Root.fusion. Every other fusion including the default fusion has to be included
+explicitly. This mimics the behavior of the classic FusionView that is used for FusionRendering of Flow Controller Actions.
+
+```YAML
+Sitegeist:
+  Monocle:
+    packages:
+      #add a key to the package list without package specific configuration
+      'Vendor.Example': {}
 ```
 
 ### Fusion
@@ -384,19 +397,19 @@ prototype(Sitegeist.Monocle:Preview.Page) {
         metaViewport = '<meta name="viewport" content="width=device-width">'
 
         stylesheets.main =  Neos.Fusion:Tag {
-           tagName = 'link'
-           attributes.rel = 'stylesheet'
-           attributes.href = Neos.Fusion:ResourceUri {
-               path = 'resource://Vendor.Site/Public/Styles/main.css'
-           }
+            tagName = 'link'
+            attributes.rel = 'stylesheet'
+            attributes.href = Neos.Fusion:ResourceUri {
+                path = 'resource://Vendor.Site/Public/Styles/main.css'
+            }
         }
 
         javascripts.main = Neos.Fusion:Tag {
-           tagName = 'script'
-           attributes.src = Neos.Fusion:ResourceUri {
-               path = 'resource://Vendor.Site/Public/JavaScript/main.js'
-           }
-       }
+            tagName = 'script'
+            attributes.src = Neos.Fusion:ResourceUri {
+                path = 'resource://Vendor.Site/Public/JavaScript/main.js'
+            }
+        }
     }
 }
 ```


### PR DESCRIPTION
The `packages` configuration can now be used to configure non-site packages for previewing in the styleguide.

When a prototyope of a non-site package is rendered Monocle will only load the Root.fusion of this specific package and the Monocle Root.fusion. Every other fusion including the default fusion has to be included explicitly. This mimics the behavior of the classic FusionView that is used for FusionRendering of Flow Controller Actions.

```YAML
Sitegeist:
  Monocle:
    packages:
      #add a key to the package list without package specific configuration
      'Vendor.Example': {}
```

In addition a smarter and configurable way to determine the defaultPackageKey was added.

If a domain can be identified from the current request monocle will use this to determine the initial sitePackage.
If that does not work a newly added setting `defaultPackageKey` is used. If this setting is not set the key of
the first site package or the first key in the `packages` configuration is used.

Relates: #109
Resolves: #115