### PR TITLE
BUGFIX: PrototypeRepository disables content cache in FusionRuntime

### DIFF
--- a/Classes/Domain/Fusion/PrototypeRepository.php
+++ b/Classes/Domain/Fusion/PrototypeRepository.php
@@ -44,6 +44,7 @@ final class PrototypeRepository
         if (isset($fusionObjectTree['__prototypes'][$prototypeName])) {
             $fusionAst =  $fusionObjectTree['__prototypes'][$prototypeName];
             $fusionRuntime = $this->fusionRuntimeFactory->create($fusionObjectTree);
+            $fusionRuntime->setEnableContentCache(false);
 
             return new Prototype(
                 PrototypeName::fromString($prototypeName),


### PR DESCRIPTION
In recent versions the API endpoint `prototypeDetails` can fail if the Prototype has a `@cache` declared. The reason is, that the fusion runtime has the content cache enabled by default. As the cache is evaluated, `Neos.Fusion:GlobalCacheIdentifiers` is used for the `entryIdentifier` which uses `documentNode` to add the `workspaceChain` like this:  
```
workspaceChain = ${documentNode.context.workspace.name + ',' + Array.join(Array.keys(documentNode.context.workspace.baseWorkspaces), ',')}
```

Since no `documentNode` is set for rendering the Prototype, `Array.keys` fails with an exception because it expects an array instead of `null`.

With this PR, the content cache is disabled in the `PrototypeRepository` and fixes the issue.