### PR TITLE
FEATURE: Allow props to be removed from Inspector

### DIFF
--- a/Classes/Domain/PrototypeDetails/Props/EditorFactory.php
+++ b/Classes/Domain/PrototypeDetails/Props/EditorFactory.php
@@ -32,6 +32,9 @@ final class EditorFactory
         Prototype $prototype,
         PropName $propName
     ): ?EditorInterface {
+        if (($hidePropsInInspector = $prototype->evaluate('/__meta/styleguide/options/hidePropsInInspector')) && in_array((string)$propName, $hidePropsInInspector, true)) {
+            return null;
+        }
         if ($manualConfiguration = $prototype->evaluate(
             sprintf(
                 '/__meta/styleguide/options/propEditors/%s<Neos.Fusion:DataStructure>',

--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ Additionally, if you need more control over which editor is used you may include
 
 ```
 prototype(Vendor.Package:MyAlertComponent) < prototype(Neos.Fusion:Component) {
-	@styleguide {
+    @styleguide {
         options {
             propEditors {
                 severity {
@@ -583,6 +583,20 @@ prototype(Vendor.Package:MyAlertComponent) < prototype(Neos.Fusion:Component) {
 An overview of available editors can be found under [[PropEditors](./Documentation/PropEditors.md)].
 
 If you are using [`PackageFactory.AtomicFusion.PropTypes`](https://github.com/PackageFactory/atomic-fusion-proptypes) then check out [`Sitegeist.Monocle.PropTypes`](https://github.com/sitegeist/Sitegeist.Monocle.PropTypes). This package automatically generates editor configurations that that fit your PropTypes.
+
+#### Hide props in Inspector
+
+Sometimes it can be useful to remove editors for props completely (for example for props that contain HTML). This can be done with the `hidePropsInInspector` option:
+
+```
+prototype(Vendor.Package:SomeComponent) < prototype(Neos.Fusion:Component) {
+    @styleguide {
+        options {
+            hidePropsInInspector = ${['header', 'content']}
+        }
+    }
+}
+```
 
 ### Fusion Object Tree Caching
 


### PR DESCRIPTION
Adds a new `@styleguide` option `hidePropsInInspector` that allows to
hide specified props in the Inspector.

Resolves: #162