### PR TITLE
BUGFIX: `@styleguide.container` doesnt get `content` prop

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Preview/Page.fusion
+++ b/Resources/Private/Fusion/Prototypes/Preview/Page.fusion
@@ -86,8 +86,8 @@ prototype(Sitegeist.Monocle:Preview.Page) < prototype(Neos.Fusion:Http.Message) 
                         renderPath = ${'/<' + prototypeName + '>/__meta/styleguide/container'}
                     }
                     renderer = Neos.Fusion:Renderer {
-                        renderPath = ${'/<' + prototypeName + '>/__meta/styleguide/container'}
-                        element.content = ${value}
+                        renderPath = ${'element<' + prototypeName + '>/__meta/styleguide/container'}
+                        element.@styleguide.container.content = ${value}
                     }
                 }
 


### PR DESCRIPTION
As shown here https://github.com/sitegeist/Sitegeist.Monocle#preview-containers
the container should automatically get the `content` prop. This is not working because

1. 'element' need to be in the custom renderPath and the path must be relative,
2. 'element.container' wont work as we need to override deeper ('element' would only be the current prototype component)

demo:
https://fusionpen.punkt.de/fusionpen/c3d9af2b6c532ef03c904b8bf711ef3bb405f36e.html