### PR TITLE
Feature: ExtensionPoint PrototypeDetailsFactory

### DIFF
--- a/Classes/Controller/ApiController.php
+++ b/Classes/Controller/ApiController.php
@@ -17,10 +17,10 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Sitegeist\Monocle\Domain\Fusion\PrototypeRepository;
+use Sitegeist\Monocle\Domain\PrototypeDetails\PrototypeDetailsFactoryInterface;
 use Sitegeist\Monocle\Fusion\FusionService;
 use Sitegeist\Monocle\Service\PackageKeyTrait;
 use Sitegeist\Monocle\Service\ConfigurationService;
-use Sitegeist\Monocle\Domain\PrototypeDetails\PrototypeDetailsFactory;
 
 /**
  * Class ApiController
@@ -67,7 +67,7 @@ class ApiController extends ActionController
 
     /**
      * @Flow\Inject
-     * @var PrototypeDetailsFactory
+     * @var PrototypeDetailsFactoryInterface
      */
     protected $prototypeDetailsFactory;
 

--- a/Classes/Domain/PrototypeDetails/PropSets/PropSetCollection.php
+++ b/Classes/Domain/PrototypeDetails/PropSets/PropSetCollection.php
@@ -30,7 +30,7 @@ final class PropSetCollection implements \JsonSerializable
     /**
      * @param PropSet ...$propSets
      */
-    private function __construct(PropSet ...$propSets)
+    public function __construct(PropSet ...$propSets)
     {
         $this->propSets = $propSets;
     }

--- a/Classes/Domain/PrototypeDetails/Props/PropValue.php
+++ b/Classes/Domain/PrototypeDetails/Props/PropValue.php
@@ -34,9 +34,12 @@ final class PropValue implements \JsonSerializable
     {
         if (!self::isValid($value)) {
             throw new \UnexpectedValueException(
-                'PropValue must be a primitive, an array or an object ' .
-                'of type \\stdClass. Got "%s" instead.',
-                is_object($value) ? get_class($value) : gettype($value)
+                sprintf(
+                    'PropValue must be a primitive, an array or an object ' .
+                    'of type \\stdClass. Got "%s" instead.',
+                    is_object($value) ? get_class($value) : gettype($value)
+                ),
+                1665434215
             );
         }
 

--- a/Classes/Domain/PrototypeDetails/PrototypeDetailsFactory.php
+++ b/Classes/Domain/PrototypeDetails/PrototypeDetailsFactory.php
@@ -25,7 +25,7 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * @Flow\Scope("singleton")
  */
-final class PrototypeDetailsFactory
+final class PrototypeDetailsFactory implements PrototypeDetailsFactoryInterface
 {
     /**
      * @Flow\Inject

--- a/Classes/Domain/PrototypeDetails/PrototypeDetailsFactoryInterface.php
+++ b/Classes/Domain/PrototypeDetails/PrototypeDetailsFactoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sitegeist\Monocle\Domain\PrototypeDetails;
+
+use Sitegeist\Monocle\Domain\Fusion\Prototype;
+
+interface PrototypeDetailsFactoryInterface
+{
+    public function forPrototype(Prototype $prototype): PrototypeDetailsInterface;
+}

--- a/Classes/Domain/PrototypeDetails/PrototypeDetailsInterface.php
+++ b/Classes/Domain/PrototypeDetails/PrototypeDetailsInterface.php
@@ -17,6 +17,7 @@ use Neos\Flow\Annotations as Flow;
 use Sitegeist\Monocle\Domain\Fusion\PrototypeName;
 use Sitegeist\Monocle\Domain\PrototypeDetails\Props\PropsCollectionInterface;
 use Sitegeist\Monocle\Domain\PrototypeDetails\PropSets\PropSetCollection;
+use Sitegeist\Monocle\Domain\PrototypeDetails\UseCases\UseCaseCollection;
 
 /**
  * @Flow\Proxy(false)
@@ -52,6 +53,11 @@ interface PrototypeDetailsInterface extends \JsonSerializable
      * @return PropsCollectionInterface
      */
     public function getProps(): PropsCollectionInterface;
+
+    /**
+     * @return UseCaseCollection
+     */
+    public function getUseCases(): UseCaseCollection;
 
     /**
      * @return PropSetCollection

--- a/Classes/Domain/PrototypeDetails/UseCases/UseCase.php
+++ b/Classes/Domain/PrototypeDetails/UseCases/UseCase.php
@@ -14,6 +14,7 @@ namespace Sitegeist\Monocle\Domain\PrototypeDetails\UseCases;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Sitegeist\Monocle\Domain\PrototypeDetails\Props\PropValue;
 
 /**
  * @Flow\Proxy(false)

--- a/Classes/Domain/PrototypeDetails/UseCases/UseCaseCollection.php
+++ b/Classes/Domain/PrototypeDetails/UseCases/UseCaseCollection.php
@@ -30,7 +30,7 @@ final class UseCaseCollection implements \JsonSerializable
     /**
      * @param UseCase ...$useCases
      */
-    private function __construct(UseCase ...$useCases)
+    public function __construct(UseCase ...$useCases)
     {
         $this->useCases = $useCases;
     }


### PR DESCRIPTION
enable it to override it like:

```yaml
Sitegeist\Monocle\Domain\PrototypeDetails\PrototypeDetailsFactoryInterface:
  className: Foo\Bar\MyFactory

```

Extension point for https://github.com/sitegeist/Sitegeist.Monocle.PresentationObjects/pull/1

...

Description is WIP will add some more details later