### PR TITLE
Fix height of usecase/propsets select

### DIFF
--- a/Resources/Private/JavaScript/containers/styleguide/header/toolbox/props-inspector/inspector/prop-set-selector/style.css
+++ b/Resources/Private/JavaScript/containers/styleguide/header/toolbox/props-inspector/inspector/prop-set-selector/style.css
@@ -9,6 +9,7 @@
     width: 100%;
     max-width: 800px;
     position: relative;
+    padding-bottom: 1rem;
 
     label {
         display: block;

--- a/Resources/Private/JavaScript/containers/styleguide/header/toolbox/props-inspector/inspector/style.css
+++ b/Resources/Private/JavaScript/containers/styleguide/header/toolbox/props-inspector/inspector/style.css
@@ -19,14 +19,6 @@
 
 .container {
     padding: 1rem;
-    flex-grow: 0;
+    flex-grow: 1;
     overflow-y: auto;
-
-    + .container {
-        background-color: rgba(0, 0, 0, .3);
-        border-top: 1px solid rgba(153, 153, 153, .3);
-        overflow-y: auto;
-        flex-grow: 1;
-        flex-shrink: 1;
-    }
 }


### PR DESCRIPTION
If not enough props are present, the useCases select dropdown is not visible.

|before|data is here|after|
|-|-|-|
|<img width="480" alt="Bildschirmfoto 2023-01-03 um 16 21 33" src="https://user-images.githubusercontent.com/3001985/210387056-f4b1f31c-33f4-4d86-b3ef-d44bba13d92e.png">|<img width="518" alt="Bildschirmfoto 2023-01-03 um 16 21 26" src="https://user-images.githubusercontent.com/3001985/210387060-2e9b2a06-a8d0-4741-9961-bc09d67f14bb.png">|<img width="495" alt="Bildschirmfoto 2023-01-03 um 16 21 48" src="https://user-images.githubusercontent.com/3001985/210387046-58a197bd-467b-4845-a8b4-30ae7579f139.png">|





Bug was probably introduced in a1c9074

