### PR TITLE
Flush `include: nodetypes://` file caches too

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -59,6 +59,13 @@ class Package extends BasePackage
                                 $templateFileMonitor->monitorDirectory($templatesPath);
                             }
                         }
+
+                        if (method_exists($package, 'getPackagePath')) {
+                            $templatesPath = $package->getPackagePath() . 'NodeTypes';
+                            if (is_dir($templatesPath)) {
+                                $templateFileMonitor->monitorDirectory($templatesPath);
+                            }
+                        }
                     }
 
                     $templateFileMonitor->detectChanges();


### PR DESCRIPTION
If the new https://github.com/neos/neos-development-collection/pull/3903 is used to work with Monocle Components in the NodeTypes directory, this Fusion files need to be flushed too.
