### PR TITLE
BUGFIX: Make Monocle work without a database setup

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -89,7 +89,7 @@ Neos:
     mvc:
       routes:
         'Sitegeist.Monocle':
-          position: 'before Neos.Neos'
+          position: 'start 1'
     security:
       authentication:
         providers:


### PR DESCRIPTION
Without this change it is not possible to run Monocle in a setup without database. Useful for frontend-only developers and automatic tests