### PR TITLE
TASK: add structure meta data to cpx components

### DIFF
--- a/Classes/StyleguideProvider/CpxPackage/CpxComponentFactory.php
+++ b/Classes/StyleguideProvider/CpxPackage/CpxComponentFactory.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
 
 namespace Sitegeist\Monocle\StyleguideProvider\CpxPackage;
 
-use Neos\Flow\Reflection\ParameterReflection;
-use org\bovigo\vfs\vfsStreamAbstractContentTestCase;
+use PackageFactory\ComponentEngine\ComponentCollection;
+use PackageFactory\ComponentEngine\ComponentCollectionInterface;
 use PackageFactory\ComponentEngine\ComponentInterface;
-use ReflectionNamedType;
+use PackageFactory\ComponentEngine\StringComponent;
 use Sitegeist\Monocle\Domain\StyleguideObjects\PropSets\PropSetName;
 use Sitegeist\Monocle\Domain\StyleguideObjects\StyleguideObjectIdentifier;
 use Sitegeist\Monocle\Domain\StyleguideObjects\UseCases\UseCaseName;
@@ -136,6 +136,15 @@ final class CpxComponentFactory
     private static function mapPropValue(mixed $value, ?\ReflectionParameter $reflection = null): mixed
     {
         if (!is_array($value)) {
+            if (
+                is_string($value)
+                && $reflection !== null
+                && self::parameterSupportsComponentList($reflection)
+                && self::looksLikeHtml($value)
+            ) {
+                return StringComponent::fromHtmlString($value);
+            }
+
             if ($reflection !== null) {
                 $type = $reflection->getType();
                 if ($type instanceof \ReflectionNamedType) {
@@ -151,8 +160,15 @@ final class CpxComponentFactory
             return $value;
         }
 
+        if (array_is_list($value) && $reflection !== null && self::parameterSupportsComponentList($reflection)) {
+            return self::createComponentCollectionFromValues($value);
+        }
+
         if (array_is_list($value)) {
-            return array_map([self::class, 'mapPropValue'], $value);
+            return array_map(
+                static fn (mixed $item): mixed => self::mapPropValue($item),
+                $value
+            );
         }
 
         if (self::isComponentConfiguration($value)) {
@@ -225,7 +241,7 @@ final class CpxComponentFactory
             if (str_starts_with($key, '__')) {
                 continue;
             }
-            $propsFiltered[$key] = self::mapPropValue($value);
+            $propsFiltered[$key] = $value;
         }
 
         $metadata = CpxComponentMetadata::fromComponentIdentifier(StyleguideObjectIdentifier::fromString($configuration['__type']));
@@ -250,7 +266,7 @@ final class CpxComponentFactory
             if (str_starts_with($key, '__')) {
                 continue;
             }
-            $propsFiltered[$key] = self::mapPropValue($value);
+            $propsFiltered[$key] = $value;
         }
 
         $className = self::classNameFromIdentifier($configuration['__type']);
@@ -266,6 +282,58 @@ final class CpxComponentFactory
         $className = self::classNameFromIdentifier($configuration['__type']);
         $value = $configuration['value'];
         return $className::from($value);
+    }
+
+    private static function createComponentCollectionFromValues(array $values): ?ComponentCollectionInterface
+    {
+        $items = [];
+        foreach ($values as $value) {
+            $mappedValue = self::mapPropValue($value);
+            if (is_string($mappedValue)) {
+                $items[] = self::looksLikeHtml($mappedValue)
+                    ? StringComponent::fromHtmlString($mappedValue)
+                    : StringComponent::fromString($mappedValue);
+                continue;
+            }
+
+            if ($mappedValue instanceof ComponentInterface || $mappedValue === null) {
+                $items[] = $mappedValue;
+                continue;
+            }
+
+            throw new \InvalidArgumentException('List props must resolve to components or strings.');
+        }
+
+        return ComponentCollection::list(...$items);
+    }
+
+    private static function parameterSupportsComponentList(\ReflectionParameter $parameter): bool
+    {
+        return self::reflectionTypeSupportsComponentList($parameter->getType());
+    }
+
+    private static function reflectionTypeSupportsComponentList(?\ReflectionType $reflectionType): bool
+    {
+        if ($reflectionType instanceof \ReflectionNamedType) {
+            $typeName = $reflectionType->getName();
+            return $typeName === ComponentCollectionInterface::class
+                || $typeName === ComponentInterface::class;
+        }
+
+        if ($reflectionType instanceof \ReflectionUnionType) {
+            foreach ($reflectionType->getTypes() as $unionedType) {
+                if (self::reflectionTypeSupportsComponentList($unionedType)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static function looksLikeHtml(string $value): bool
+    {
+        return preg_match('/<[^>]+>/', $value) === 1;
     }
 
     /**

--- a/Classes/StyleguideProvider/CpxPackage/CpxComponentMetadata.php
+++ b/Classes/StyleguideProvider/CpxPackage/CpxComponentMetadata.php
@@ -112,9 +112,20 @@ readonly class CpxComponentMetadata
         return $phpClass;
     }
 
+    public function isHidden(): bool
+    {
+        return (bool)($this->readStyleguideConfiguration()['hidden'] ?? false);
+    }
+
+    public function getGroup(): ?string
+    {
+        $group = $this->readStyleguideConfiguration()['group'] ?? null;
+        return is_string($group) && $group !== '' ? $group : null;
+    }
+
     public function prepareStyleguideObjectDetails(): StyleguideObjectDetails
     {
-        $config = Yaml::parseFile($this->componentStyleguideConfigFile);
+        $config = $this->readStyleguideConfiguration();
 
         $props = [];
 
@@ -225,5 +236,11 @@ readonly class CpxComponentMetadata
             new PropSetCollection(...$propSets),
             new UseCaseCollection(...$useCases)
         );
+    }
+
+    private function readStyleguideConfiguration(): array
+    {
+        $config = Yaml::parseFile($this->componentStyleguideConfigFile);
+        return is_array($config) ? $config : [];
     }
 }

--- a/Classes/StyleguideProvider/CpxPackage/CpxPackageStyleguide.php
+++ b/Classes/StyleguideProvider/CpxPackage/CpxPackageStyleguide.php
@@ -25,6 +25,8 @@ use PackageFactory\Neos\ComponentEngine\Application\Transpiler\TranspilerConfigu
 use Sitegeist\Monocle\Domain\StyleguideAddress;
 use Sitegeist\Monocle\Domain\StyleguideIdentifier;
 use Sitegeist\Monocle\Domain\StyleguideInterface;
+use Sitegeist\Monocle\Domain\StyleguideObjects\StyleguideObject;
+use Sitegeist\Monocle\Domain\StyleguideObjects\StyleguideStructure;
 use Sitegeist\Monocle\Domain\StyleguideObjects\PropSets\PropSetName;
 use Sitegeist\Monocle\Domain\StyleguideObjects\StyleguideObjectCollection;
 use Sitegeist\Monocle\Domain\StyleguideObjects\StyleguideObjectDetails;
@@ -119,6 +121,7 @@ class CpxPackageStyleguide implements StyleguideInterface
     private function buildItemList(): CpxComponentMetadataCollection
     {
         $items = [];
+        $prototypeStructures = $this->configurationService->getStyleguideConfiguration($this->getStyleguideAddress(), 'ui.structure');
         $transpilerConfiguration = $this->transpilerConfigurationLoader->forPackage($this->package->getPackageKey());
         foreach ($transpilerConfiguration as $configuration) {
             /**
@@ -134,8 +137,46 @@ class CpxPackageStyleguide implements StyleguideInterface
                 continue;
             }
 
-            $items[] = $metadata;
+            $items[] = new CpxComponentMetadata(
+                $this->resolveStyleguideObject($metadata->styleguideObject, is_array($prototypeStructures) ? $prototypeStructures : []),
+                $metadata->componentPhpClassName,
+                $metadata->componentStyleguideConfigFile
+            );
         }
         return new CpxComponentMetadataCollection(...$items);
+    }
+
+    private function resolveStyleguideObject(StyleguideObject $styleguideObject, array $prototypeStructures): StyleguideObject
+    {
+        return new StyleguideObject(
+            $styleguideObject->identifier,
+            $styleguideObject->name,
+            $styleguideObject->path,
+            $this->getStructureForComponentPath($prototypeStructures, $styleguideObject->path->value),
+            $styleguideObject->description
+        );
+    }
+
+    private function getStructureForComponentPath(array $prototypeStructures, string $componentPath): StyleguideStructure
+    {
+        foreach ($prototypeStructures as $structure) {
+            if (!isset($structure['match'], $structure['label'], $structure['icon'], $structure['color'])) {
+                continue;
+            }
+
+            if (preg_match(sprintf('!%s!', $structure['match']), $componentPath)) {
+                return new StyleguideStructure(
+                    $structure['label'],
+                    $structure['icon'],
+                    $structure['color'],
+                );
+            }
+        }
+
+        return new StyleguideStructure(
+            'Other',
+            'icon-question',
+            'white'
+        );
     }
 }

--- a/Classes/StyleguideProvider/CpxPackage/CpxPackageStyleguide.php
+++ b/Classes/StyleguideProvider/CpxPackage/CpxPackageStyleguide.php
@@ -136,9 +136,12 @@ class CpxPackageStyleguide implements StyleguideInterface
             if (!file_exists($metadata->componentStyleguideConfigFile)) {
                 continue;
             }
+            if ($metadata->isHidden()) {
+                continue;
+            }
 
             $items[] = new CpxComponentMetadata(
-                $this->resolveStyleguideObject($metadata->styleguideObject, is_array($prototypeStructures) ? $prototypeStructures : []),
+                $this->resolveStyleguideObject($metadata, is_array($prototypeStructures) ? $prototypeStructures : []),
                 $metadata->componentPhpClassName,
                 $metadata->componentStyleguideConfigFile
             );
@@ -146,13 +149,16 @@ class CpxPackageStyleguide implements StyleguideInterface
         return new CpxComponentMetadataCollection(...$items);
     }
 
-    private function resolveStyleguideObject(StyleguideObject $styleguideObject, array $prototypeStructures): StyleguideObject
+    private function resolveStyleguideObject(CpxComponentMetadata $metadata, array $prototypeStructures): StyleguideObject
     {
+        $styleguideObject = $metadata->styleguideObject;
+        $groupOrPath = $metadata->getGroup() ?? $styleguideObject->path->value;
+
         return new StyleguideObject(
             $styleguideObject->identifier,
             $styleguideObject->name,
             $styleguideObject->path,
-            $this->getStructureForComponentPath($prototypeStructures, $styleguideObject->path->value),
+            $this->getStructureForComponentPath($prototypeStructures, $groupOrPath),
             $styleguideObject->description
         );
     }

--- a/Tests/Unit/StyleguideProvider/CpxPackage/CpxComponentFactoryTest.php
+++ b/Tests/Unit/StyleguideProvider/CpxPackage/CpxComponentFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Sitegeist\Monocle\Tests\Unit\StyleguideProvider\CpxPackage;
 
 use PHPUnit\Framework\TestCase;
+use PackageFactory\ComponentEngine\ComponentCollectionInterface;
 use Sitegeist\Monocle\Domain\StyleguideObjects\StyleguideObject;
 use Sitegeist\Monocle\Domain\StyleguideObjects\StyleguideObjectIdentifier;
 use Sitegeist\Monocle\Domain\StyleguideObjects\StyleguideObjectName;
@@ -13,16 +14,22 @@ use Sitegeist\Monocle\Domain\StyleguideObjects\PropSets\PropSetName;
 use Sitegeist\Monocle\Domain\StyleguideObjects\UseCases\UseCaseName;
 use Sitegeist\Monocle\StyleguideProvider\CpxPackage\CpxComponentMetadata;
 use Sitegeist\Monocle\StyleguideProvider\CpxPackage\CpxComponentFactory;
+use Sitegeist\Monocle\Tests\Components\CollectionHost\CollectionHostComponent;
 use Sitegeist\Monocle\Tests\Components\Enum\EnumComponent;
 use Sitegeist\Monocle\Tests\Components\Enum\Status;
 use Sitegeist\Monocle\Tests\Components\ListItem\ListItemComponent;
+use Sitegeist\Monocle\Tests\Components\ModernListItem\ModernListItemComponent;
 use Sitegeist\Monocle\Tests\Components\Nested\NestedComponent;
 use Sitegeist\Monocle\Tests\Components\Primary\PrimaryComponent;
+use Sitegeist\Monocle\Tests\Components\SlotHost\SlotHostComponent;
 
 require_once __DIR__ . '/Fixtures/ComponentFactory/Components/Enum/Status.php';
 require_once __DIR__ . '/Fixtures/ComponentFactory/Components/Enum/EnumComponent.php';
+require_once __DIR__ . '/Fixtures/ComponentFactory/Components/ModernListItem/ModernListItemComponent.php';
 require_once __DIR__ . '/Fixtures/ComponentFactory/Components/ListItem/ListItemComponent.php';
 require_once __DIR__ . '/Fixtures/ComponentFactory/Components/Nested/NestedComponent.php';
+require_once __DIR__ . '/Fixtures/ComponentFactory/Components/SlotHost/SlotHostComponent.php';
+require_once __DIR__ . '/Fixtures/ComponentFactory/Components/CollectionHost/CollectionHostComponent.php';
 require_once __DIR__ . '/Fixtures/ComponentFactory/Components/Primary/PrimaryComponent.php';
 
 final class CpxComponentFactoryTest extends TestCase
@@ -147,6 +154,87 @@ final class CpxComponentFactoryTest extends TestCase
         self::assertSame('compact', $component->items[0]);
         self::assertInstanceOf(NestedComponent::class, $component->nested);
         self::assertSame('Nested Compact', $component->nested->label);
+    }
+
+    public function testSlotPropSupportsDirectComponentConfiguration(): void
+    {
+        $component = CpxComponentFactory::create(
+            $this->createMetadata(
+                'Sitegeist.Monocle.Tests/SlotHost/SlotHostComponent',
+                SlotHostComponent::class,
+                __DIR__ . '/Fixtures/ComponentFactory/Components/SlotHost/SlotHostComponent.styleguide.yaml'
+            )
+        );
+
+        self::assertInstanceOf(SlotHostComponent::class, $component);
+        self::assertInstanceOf(ModernListItemComponent::class, $component->content);
+        self::assertSame('[item:single]', $component->render());
+    }
+
+    public function testSlotPropSupportsMultipleComponentConfigurations(): void
+    {
+        $component = CpxComponentFactory::create(
+            $this->createMetadata(
+                'Sitegeist.Monocle.Tests/SlotHost/SlotHostComponent',
+                SlotHostComponent::class,
+                __DIR__ . '/Fixtures/ComponentFactory/Components/SlotHost/SlotHostComponent.styleguide.yaml'
+            ),
+            [],
+            null,
+            UseCaseName::fromString('multipleComponents')
+        );
+
+        self::assertInstanceOf(ComponentCollectionInterface::class, $component->content);
+        self::assertSame('[item:first][item:second]', $component->render());
+    }
+
+    public function testSlotPropSupportsMixedStringsAndComponents(): void
+    {
+        $component = CpxComponentFactory::create(
+            $this->createMetadata(
+                'Sitegeist.Monocle.Tests/SlotHost/SlotHostComponent',
+                SlotHostComponent::class,
+                __DIR__ . '/Fixtures/ComponentFactory/Components/SlotHost/SlotHostComponent.styleguide.yaml'
+            ),
+            [],
+            null,
+            UseCaseName::fromString('mixedList')
+        );
+
+        self::assertInstanceOf(ComponentCollectionInterface::class, $component->content);
+        self::assertSame('alpha[item:middle]omega', $component->render());
+    }
+
+    public function testSlotPropSupportsPlainStringContent(): void
+    {
+        $component = CpxComponentFactory::create(
+            $this->createMetadata(
+                'Sitegeist.Monocle.Tests/SlotHost/SlotHostComponent',
+                SlotHostComponent::class,
+                __DIR__ . '/Fixtures/ComponentFactory/Components/SlotHost/SlotHostComponent.styleguide.yaml'
+            ),
+            [],
+            null,
+            UseCaseName::fromString('stringOnly')
+        );
+
+        self::assertSame('just text', $component->content);
+        self::assertSame('just text', $component->render());
+    }
+
+    public function testCollectionPropSupportsMultipleComponentConfigurations(): void
+    {
+        $component = CpxComponentFactory::create(
+            $this->createMetadata(
+                'Sitegeist.Monocle.Tests/CollectionHost/CollectionHostComponent',
+                CollectionHostComponent::class,
+                __DIR__ . '/Fixtures/ComponentFactory/Components/CollectionHost/CollectionHostComponent.styleguide.yaml'
+            )
+        );
+
+        self::assertInstanceOf(CollectionHostComponent::class, $component);
+        self::assertInstanceOf(ComponentCollectionInterface::class, $component->content);
+        self::assertSame('[item:first][item:second]', $component->render());
     }
 
     private function createMetadata(string $identifier, string $className, string $styleguideFile): CpxComponentMetadata

--- a/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/CollectionHost/CollectionHostComponent.php
+++ b/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/CollectionHost/CollectionHostComponent.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\Monocle\Tests\Components\CollectionHost;
+
+use PackageFactory\ComponentEngine\ComponentCollectionInterface;
+use PackageFactory\ComponentEngine\ComponentInterface;
+
+final class CollectionHostComponent implements ComponentInterface
+{
+    public function __construct(
+        public readonly ?ComponentCollectionInterface $content,
+    ) {
+    }
+
+    public static function create(?ComponentCollectionInterface $content = null): self
+    {
+        return new self($content);
+    }
+
+    public function render(): string
+    {
+        return $this->content?->render() ?? '';
+    }
+}

--- a/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/CollectionHost/CollectionHostComponent.styleguide.yaml
+++ b/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/CollectionHost/CollectionHostComponent.styleguide.yaml
@@ -1,0 +1,8 @@
+title: "Collection Host"
+description: "Component with collection content"
+props:
+  content:
+    - __type: "Sitegeist.Monocle.Tests/ModernListItem/ModernListItemComponent"
+      label: "first"
+    - __type: "Sitegeist.Monocle.Tests/ModernListItem/ModernListItemComponent"
+      label: "second"

--- a/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/Enum/EnumComponent.php
+++ b/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/Enum/EnumComponent.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Sitegeist\Monocle\Tests\Components\Enum;
 
-use PackageFactory\PHPComponentEngine\ComponentInterface;
+use PackageFactory\ComponentEngine\ComponentInterface;
 
 final class EnumComponent implements ComponentInterface
 {

--- a/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/ListItem/ListItemComponent.php
+++ b/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/ListItem/ListItemComponent.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Sitegeist\Monocle\Tests\Components\ListItem;
 
-use PackageFactory\PHPComponentEngine\ComponentInterface;
+use PackageFactory\ComponentEngine\ComponentInterface;
 
 final class ListItemComponent implements ComponentInterface
 {

--- a/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/ModernListItem/ModernListItemComponent.php
+++ b/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/ModernListItem/ModernListItemComponent.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace Sitegeist\Monocle\Tests\Components\Nested;
+namespace Sitegeist\Monocle\Tests\Components\ModernListItem;
 
 use PackageFactory\ComponentEngine\ComponentInterface;
 
-final class NestedComponent implements ComponentInterface
+final class ModernListItemComponent implements ComponentInterface
 {
     public function __construct(
         public readonly string $label,
@@ -19,6 +19,6 @@ final class NestedComponent implements ComponentInterface
 
     public function render(): string
     {
-        return '';
+        return sprintf('[item:%s]', $this->label);
     }
 }

--- a/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/ModernListItem/ModernListItemComponent.styleguide.yaml
+++ b/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/ModernListItem/ModernListItemComponent.styleguide.yaml
@@ -1,0 +1,4 @@
+title: "Modern List Item"
+description: "Component item for current ComponentEngine fixtures"
+props:
+  label: "default"

--- a/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/Primary/PrimaryComponent.php
+++ b/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/Primary/PrimaryComponent.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Sitegeist\Monocle\Tests\Components\Primary;
 
-use PackageFactory\PHPComponentEngine\ComponentInterface;
+use PackageFactory\ComponentEngine\ComponentInterface;
 
 final class PrimaryComponent implements ComponentInterface
 {

--- a/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/SlotHost/SlotHostComponent.php
+++ b/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/SlotHost/SlotHostComponent.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\Monocle\Tests\Components\SlotHost;
+
+use PackageFactory\ComponentEngine\ComponentInterface;
+
+final class SlotHostComponent implements ComponentInterface
+{
+    public function __construct(
+        public readonly ComponentInterface|string|null $content,
+    ) {
+    }
+
+    public static function create(ComponentInterface|string|null $content = null): self
+    {
+        return new self($content);
+    }
+
+    public function render(): string
+    {
+        if (is_string($this->content)) {
+            return $this->content;
+        }
+
+        return $this->content?->render() ?? '';
+    }
+}

--- a/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/SlotHost/SlotHostComponent.styleguide.yaml
+++ b/Tests/Unit/StyleguideProvider/CpxPackage/Fixtures/ComponentFactory/Components/SlotHost/SlotHostComponent.styleguide.yaml
@@ -1,0 +1,24 @@
+title: "Slot Host"
+description: "Component with slot-like content"
+props:
+  content:
+    __type: "Sitegeist.Monocle.Tests/ModernListItem/ModernListItemComponent"
+    label: "single"
+useCases:
+  multipleComponents:
+    props:
+      content:
+        - __type: "Sitegeist.Monocle.Tests/ModernListItem/ModernListItemComponent"
+          label: "first"
+        - __type: "Sitegeist.Monocle.Tests/ModernListItem/ModernListItemComponent"
+          label: "second"
+  mixedList:
+    props:
+      content:
+        - "alpha"
+        - __type: "Sitegeist.Monocle.Tests/ModernListItem/ModernListItemComponent"
+          label: "middle"
+        - "omega"
+  stringOnly:
+    props:
+      content: "just text"


### PR DESCRIPTION
Added three new Features:

Feature 1:
Added CPX styleguide metadata support

Feature 2:
Added explicit group and hidden support for CPX styleguides

Feature 3:
Added list-based prop normalization for slot and collection-like props, while preserving singular prop behavior